### PR TITLE
Fix link issue with bellingcat.com

### DIFF
--- a/general-osint-info/training/README.md
+++ b/general-osint-info/training/README.md
@@ -21,4 +21,4 @@ todo, i need to make all of these into individual sub pages
 
 [https://osintcurio.us/](https://osintcurio.us)
 
-[https://www.bellingcat.com/](bellingcat)
+[https://www.bellingcat.com/](https://www.bellingcat.com/)


### PR DESCRIPTION
I messed up the link creation for bellingcat.  The link didn't work previously.  It has now been corrected.